### PR TITLE
Add filesystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,8 @@
     },
     "require": {
         "php": "^7.4",
+        "league/flysystem": "^2.0@dev",
+        "yiisoft/aliases": "^3.0@dev",
         "yiisoft/strings": "^3.0@dev"
     },
     "require-dev": {
@@ -34,6 +36,10 @@
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
+        },
+        "config-plugin": {
+            "common": "config/common.php",
+            "providers": "config/providers.php"
         }
     },
     "config": {

--- a/config/common.php
+++ b/config/common.php
@@ -1,0 +1,37 @@
+<?php
+
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
+use Yiisoft\Files\FilesystemInterface;
+use Yiisoft\Files\Filesystem;
+use Yiisoft\Files\FileStorageConfigs;
+
+return [
+    FilesystemInterface::class => function () use ($params) {
+        $aliases = $params['aliases'] ?? [];
+        if (!isset($aliases['@root'])) {
+            throw new \InvalidArgumentException('Alias of the root directory is not defined.');
+        }
+
+        $adapter = new LocalFilesystemAdapter(
+            $aliases['@root'],
+            PortableVisibilityConverter::fromArray([
+                'file' => [
+                    'public' => 0644,
+                    'private' => 0600,
+                ],
+                'dir' => [
+                    'public' => 0755,
+                    'private' => 0700,
+                ],
+            ]),
+            LOCK_EX,
+            LocalFilesystemAdapter::DISALLOW_LINKS
+        );
+        return new Filesystem($adapter, $aliases);
+    },
+    FileStorageConfigs::class => function () use ($params) {
+        $configs = $params['file.storage'] ?? [];
+        return new FileStorageConfigs($configs);
+    }
+];

--- a/config/common.php
+++ b/config/common.php
@@ -10,7 +10,7 @@ return [
     FilesystemInterface::class => function () use ($params) {
         $aliases = $params['aliases'] ?? [];
         if (!isset($aliases['@root'])) {
-            throw new \InvalidArgumentException('Alias of the root directory is not defined.');
+            throw new \RuntimeException('Alias of the root directory is not defined.');
         }
 
         $adapter = new LocalFilesystemAdapter(

--- a/config/common.php
+++ b/config/common.php
@@ -7,7 +7,7 @@ use Yiisoft\Files\Filesystem;
 use Yiisoft\Files\FileStorageConfigs;
 
 return [
-    FilesystemInterface::class => function () use ($params) {
+    FilesystemInterface::class => static function () use ($params) {
         $aliases = $params['aliases'] ?? [];
         if (!isset($aliases['@root'])) {
             throw new \RuntimeException('Alias of the root directory is not defined.');
@@ -30,7 +30,7 @@ return [
         );
         return new Filesystem($adapter, $aliases);
     },
-    FileStorageConfigs::class => function () use ($params) {
+    FileStorageConfigs::class => static function () use ($params) {
         $configs = $params['file.storage'] ?? [];
         return new FileStorageConfigs($configs);
     }

--- a/config/providers.php
+++ b/config/providers.php
@@ -1,0 +1,7 @@
+<?php
+
+use Yiisoft\Files\FileStorageServiceProvider;
+
+return [
+  FileStorageServiceProvider::class
+];

--- a/src/FileStorageConfigs.php
+++ b/src/FileStorageConfigs.php
@@ -4,7 +4,7 @@ namespace Yiisoft\Files;
 
 final class FileStorageConfigs
 {
-    private array $storageConfigs = [];
+    private array $storageConfigs;
 
     public function __construct(array $storageConfigs)
     {

--- a/src/FileStorageConfigs.php
+++ b/src/FileStorageConfigs.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yiisoft\Files;
+
+class FileStorageConfigs
+{
+    private array $storageConfigs = [];
+
+    public function __construct(array $storageConfigs)
+    {
+        $this->storageConfigs = $storageConfigs;
+    }
+
+    public function getConfigs(): array
+    {
+        return $this->storageConfigs;
+    }
+}

--- a/src/FileStorageConfigs.php
+++ b/src/FileStorageConfigs.php
@@ -2,7 +2,7 @@
 
 namespace Yiisoft\Files;
 
-class FileStorageConfigs
+final class FileStorageConfigs
 {
     private array $storageConfigs = [];
 

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -18,9 +18,7 @@ final class FileStorageServiceProvider extends ServiceProvider
             $configParams = $config['config'] ?? [];
             $aliases = $config['aliases'] ?? [];
             $adapter = $factory->create($config['adapter']);
-            $container->set($alias, function () use ($adapter, $aliases, $configParams) {
-                return new Filesystem($adapter, $aliases, $configParams);
-            });
+            $container->set($alias, fn () => new Filesystem($adapter, $aliases, $configParams));
         }
     }
 

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -18,7 +18,12 @@ class FileStorageServiceProvider extends ServiceProvider
             $configParams = $config['config'] ?? [];
             $aliases = $config['aliases'] ?? [];
             $adapter = $factory->create($config['adapter']);
-            $container->set($alias, new Filesystem($adapter, $aliases, $configParams));
+            $container->set($alias, [
+                '__class' => Filesystem::class,
+                '__construct()' => [
+                    $adapter, $aliases, $configParams
+                    ]
+            ]);
         }
     }
 

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -22,14 +22,14 @@ final class FileStorageServiceProvider extends ServiceProvider
         }
     }
 
-    private function validateAdapter(string $alias, array $config)
+    private function validateAdapter(string $alias, array $config): void
     {
         $adapter = $config['adapter']['__class'] ?? false;
         if (!$adapter) {
             throw new \RuntimeException("Adapter is not defined in the '$alias' storage config.");
         }
         if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
-            throw new \RuntimeException("Adapter must implements FilesystemAdapterInterface.");
+            throw new \RuntimeException('Adapter must implement FilesystemAdapterInterface.');
         }
     }
 }

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -7,7 +7,7 @@ use Yiisoft\Di\Container;
 use Yiisoft\Di\Support\ServiceProvider;
 use Yiisoft\Factory\Factory;
 
-class FileStorageServiceProvider extends ServiceProvider
+final class FileStorageServiceProvider extends ServiceProvider
 {
     public function register(Container $container): void
     {
@@ -31,10 +31,10 @@ class FileStorageServiceProvider extends ServiceProvider
     {
         $adapter = $config['adapter']['__class'] ?? false;
         if (!$adapter) {
-            throw new \InvalidArgumentException("Adapter is not defined in the '$alias' storage config.");
+            throw new \RuntimeException("Adapter is not defined in the '$alias' storage config.");
         }
         if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
-            throw new \InvalidArgumentException("Adapter must implements FilesystemAdapterInterface.");
+            throw new \RuntimeException("Adapter must implements FilesystemAdapterInterface.");
         }
     }
 }

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Yiisoft\Files;
+
+use League\Flysystem\FilesystemAdapter;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\Support\ServiceProvider;
+use Yiisoft\Factory\Factory;
+
+class FileStorageServiceProvider extends ServiceProvider
+{
+    public function register(Container $container): void
+    {
+        $factory = new Factory();
+        $configs = $container->get(FileStorageConfigs::class)->getConfigs();
+        foreach ($configs as $alias => $config) {
+            $this->validateAdapter($alias, $config);
+            $configParams = $config['config'] ?? [];
+            $aliases = $config['aliases'] ?? [];
+            $adapter = $factory->create($config['adapter']);
+            $container->set($alias, new Filesystem($adapter, $aliases, $configParams));
+        }
+    }
+
+    private function validateAdapter(string $alias, array $config)
+    {
+        $adapter = $config['adapter']['__class'] ?? false;
+        if (!$adapter) {
+            throw new \InvalidArgumentException("Adapter is not defined in the '$alias' storage config.");
+        }
+        if (!is_subclass_of($adapter, FilesystemAdapter::class)) {
+            throw new \InvalidArgumentException("Adapter must implements FilesystemAdapterInterface.");
+        }
+    }
+}

--- a/src/FileStorageServiceProvider.php
+++ b/src/FileStorageServiceProvider.php
@@ -18,12 +18,9 @@ final class FileStorageServiceProvider extends ServiceProvider
             $configParams = $config['config'] ?? [];
             $aliases = $config['aliases'] ?? [];
             $adapter = $factory->create($config['adapter']);
-            $container->set($alias, [
-                '__class' => Filesystem::class,
-                '__construct()' => [
-                    $adapter, $aliases, $configParams
-                    ]
-            ]);
+            $container->set($alias, function () use ($adapter, $aliases, $configParams) {
+                return new Filesystem($adapter, $aliases, $configParams);
+            });
         }
     }
 

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Yiisoft\Files;
+
+use League\Flysystem\Filesystem as LeagueFilesystem;
+use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\PathNormalizer;
+use Yiisoft\Aliases\Aliases;
+
+class Filesystem extends LeagueFilesystem implements FilesystemInterface
+{
+    private Aliases $aliases;
+
+    public function __construct(FilesystemAdapter $adapter, array $aliases = [], array $config = [], PathNormalizer $pathNormalizer = null)
+    {
+        if ($aliases !== []) {
+            $aliases = array_merge(['@root' => ''], $aliases);
+            $aliases['@root'] = '';
+        }
+        $this->aliases = new Aliases($aliases);
+
+        parent::__construct($adapter, $config, $pathNormalizer);
+    }
+
+    public function fileExists(string $location): bool
+    {
+        $location = $this->aliases->get($location);
+        return parent::fileExists($location);
+    }
+
+    public function write(string $location, string $contents, array $config = []): void
+    {
+        $location = $this->aliases->get($location);
+        parent::write($location, $contents, $config);
+    }
+
+    public function writeStream(string $location, $contents, array $config = []): void
+    {
+        $location = $this->aliases->get($location);
+        parent::writeStream($location, $contents, $config);
+    }
+
+    public function read(string $location): string
+    {
+        $location = $this->aliases->get($location);
+        return parent::read($location);
+    }
+
+    public function readStream(string $location)
+    {
+        $location = $this->aliases->get($location);
+        return parent::readStream($location);
+    }
+
+    public function delete(string $location): void
+    {
+        $location = $this->aliases->get($location);
+        parent::delete($location);
+    }
+
+    public function createDirectory(string $location, array $config = []): void
+    {
+        $location = $this->aliases->get($location);
+        parent::createDirectory($location, $config);
+    }
+
+    public function deleteDirectory(string $location): void
+    {
+        $location = $this->aliases->get($location);
+        parent::deleteDirectory($location);
+    }
+
+    public function copy(string $source, string $destination, array $config = []): void
+    {
+        $source = $this->aliases->get($source);
+        $destination = $this->aliases->get($destination);
+        parent::copy($source, $destination, $config);
+    }
+
+    public function move(string $source, string $destination, array $config = []): void
+    {
+        $source = $this->aliases->get($source);
+        $destination = $this->aliases->get($destination);
+        parent::move($source, $destination, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $path = $this->aliases->get($path);
+        parent::setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): string
+    {
+        $path = $this->aliases->get($path);
+        return parent::visibility($path);
+    }
+
+    public function mimeType(string $path): string
+    {
+        $path = $this->aliases->get($path);
+        return parent::mimeType($path);
+    }
+
+    public function lastModified(string $path): int
+    {
+        $path = $this->aliases->get($path);
+        return parent::lastModified($path);
+    }
+
+    public function listContents(string $location, bool $deep = LeagueFilesystem::LIST_SHALLOW): \League\Flysystem\DirectoryListing
+    {
+        $location = $this->aliases->get($location);
+        return parent::listContents($location, $deep);
+    }
+
+    public function fileSize(string $path): int
+    {
+        $path = $this->aliases->get($path);
+        return parent::fileSize($path);
+    }
+}

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Yiisoft\Files;
+
+use League\Flysystem\FilesystemOperator;
+
+interface FilesystemInterface extends FilesystemOperator
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets #11  fixed by the PR, if any

After the package is installed you can just get `Yiisoft\Files\FilesystemInterface` to get the local filesystem with root as defined in the `@root` alias (commonly is a project root). Aliases are supported.
```php
public function index(FilesystemInterface $filesystem): ResponseInterface
{
    $filesystem->write('@views/site/test.txt', 'Test');
}
```
Also you can define any quantity of file storages in the `config/params.php` 
```php
'file.storage' => [
        'runtimeStorage' => [
            'adapter' => [
                '__class' => \League\Flysystem\Local\LocalFilesystemAdapter::class,
                '__construct()' => [
                    dirname(__DIR__) . '/runtime',
                    \League\Flysystem\UnixVisibility\PortableVisibilityConverter::fromArray([
                        'file' => [
                            'public' => 0644,
                            'private' => 0600,
                        ],
                        'dir' => [
                            'public' => 0755,
                            'private' => 0700,
                        ],
                    ]),
                    LOCK_EX,
                    \League\Flysystem\Local\LocalFilesystemAdapter::DISALLOW_LINKS
                ]
            ],
            'aliases' => [
                '@cache' => '@root/cache',
            ]
        ]
    ],
```
After that you can get the selected filesystem from the container by the alias.
```php
public function index(ContainerInterface $container): ResponseInterface
{ 
    $runtimeFilesystem = $container->get('runtimeStorage');
    $runtimeFilesystem->write('@cache/test-cahe.txt', 'Test Cache'));
}
```