### PR TITLE
Add clearDirectory() method based on removeDirectory()

### DIFF
--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -178,12 +178,14 @@ class FileHelper
             closedir($handle);
         }
 
-        if (!$keepRootDirectory) {
-            if (is_link($directory)) {
-                self::unlink($directory);
-            } else {
-                rmdir($directory);
-            }
+        if ($keepRootDirectory) {
+            return;
+        }
+
+        if (is_link($directory)) {
+            self::unlink($directory);
+        } else {
+            rmdir($directory);
         }
     }
 

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -150,12 +150,10 @@ class FileHelper
     public static function removeDirectory(string $directory, array $options = []): void
     {
         try {
-            $handle = static::openDirectory($directory);
+            static::clearDirectory($directory, $options);
         } catch (\InvalidArgumentException $e) {
             return;
         }
-
-        static::clearDirectoryByHandle($handle, $directory, $options);
 
         if (is_link($directory)) {
             self::unlink($directory);
@@ -174,23 +172,13 @@ class FileHelper
      *   Defaults to `false`, meaning the content of the symlinked directory would not be deleted.
      *   Only symlink would be removed in that default case.
      *
+     * @throws \InvalidArgumentException if unable to open directory
+     *
      * @return void
      */
     public static function clearDirectory(string $directory, array $options = []): void
     {
         $handle = static::openDirectory($directory);
-        static::clearDirectoryByHandle($handle, $directory, $options);
-    }
-
-    /**
-     * @param resource $handle
-     * @param string $directory
-     * @param array $options
-     *
-     * @return void
-     */
-    private static function clearDirectoryByHandle($handle, string $directory, array $options): void
-    {
         if (!empty($options['traverseSymlinks']) || !is_link($directory)) {
             while (($file = readdir($handle)) !== false) {
                 if ($file === '.' || $file === '..') {

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -188,7 +188,7 @@ class FileHelper
     }
 
     /**
-     * Removes a directory (and all its content) recursively.
+     * Clear all directory content.
      *
      * @param string $directory the directory to be cleared.
      * @param array $options options for directory clear ({@see removeDirectory()}).

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -149,10 +149,15 @@ class FileHelper
      *   Defaults to `false`, meaning the content of the symlinked directory would not be deleted.
      *   Only symlink would be removed in that default case.
      *
+     * - keepRootDirectory: boolean, whether only clear directory.
+     *
      * @return void
      */
     public static function removeDirectory(string $directory, array $options = []): void
     {
+        $keepRootDirectory = !empty($options['keepRootDirectory']);
+        unset($options['keepRootDirectory']);
+
         if (!empty($options['traverseSymlinks']) || !is_link($directory)) {
             if (!($handle = @opendir($directory))) {
                 return;
@@ -173,11 +178,28 @@ class FileHelper
             closedir($handle);
         }
 
-        if (is_link($directory)) {
-            self::unlink($directory);
-        } else {
-            rmdir($directory);
+        if (!$keepRootDirectory) {
+            if (is_link($directory)) {
+                self::unlink($directory);
+            } else {
+                rmdir($directory);
+            }
         }
+    }
+
+    /**
+     * Removes a directory (and all its content) recursively.
+     *
+     * @param string $directory the directory to be cleared.
+     * @param array $options options for directory clear ({@see removeDirectory()}).
+     *
+     * @return void
+     */
+    public static function clearDirectory(string $directory, array $options = []): void
+    {
+        self::removeDirectory($directory, array_merge($options, [
+            'keepRootDirectory' => true,
+        ]));
     }
 
     /**

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -163,6 +163,29 @@ final class FileHelperTest extends TestCase
         $this->assertFileDoesNotExist($basePath . 'symlinks/symlinked-directory/standard-file-1');
     }
 
+    public function testClearDirectory(): void
+    {
+        $dirName = 'test_dir_for_remove';
+
+        $this->createFileStructure([
+            $dirName => [
+                'file1.txt' => 'file 1 content',
+                'test_sub_dir' => [
+                    'sub_dir_file_1.txt' => 'sub dir file 1 content',
+                ],
+            ],
+        ]);
+
+        $basePath = $this->testFilePath;
+        $dirName = $basePath . '/' . $dirName;
+
+        FileHelper::clearDirectory($dirName);
+
+        $this->assertDirectoryExists($dirName);
+        $this->assertFileDoesNotExist($dirName . '/file1.txt');
+        $this->assertDirectoryDoesNotExist($dirName . '/test_sub_dir');
+    }
+
     public function testNormalizePath(): void
     {
         $this->assertEquals('/a/b', FileHelper::normalizePath('//a\\b/'));

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -75,7 +75,7 @@ final class FileHelperTest extends TestCase
 
         FileHelper::removeDirectory($dirName);
 
-        $this->assertFileNotExists($dirName, 'Unable to remove directory!');
+        $this->assertFileDoesNotExist($dirName, 'Unable to remove directory!');
 
         // should be silent about non-existing directories
         FileHelper::removeDirectory($basePath . '/nonExisting');
@@ -115,11 +115,11 @@ final class FileHelperTest extends TestCase
         $this->assertFileExists($basePath . 'file');
         $this->assertDirectoryExists($basePath . 'directory');
         $this->assertFileExists($basePath . 'directory/standard-file-1'); // symlinked directory still have it's file
-        $this->assertDirectoryNotExists($basePath . 'symlinks');
-        $this->assertFileNotExists($basePath . 'symlinks/standard-file-2');
-        $this->assertFileNotExists($basePath . 'symlinks/symlinked-file');
-        $this->assertDirectoryNotExists($basePath . 'symlinks/symlinked-directory');
-        $this->assertFileNotExists($basePath . 'symlinks/symlinked-directory/standard-file-1');
+        $this->assertDirectoryDoesNotExist($basePath . 'symlinks');
+        $this->assertFileDoesNotExist($basePath . 'symlinks/standard-file-2');
+        $this->assertFileDoesNotExist($basePath . 'symlinks/symlinked-file');
+        $this->assertDirectoryDoesNotExist($basePath . 'symlinks/symlinked-directory');
+        $this->assertFileDoesNotExist($basePath . 'symlinks/symlinked-directory/standard-file-1');
     }
 
     public function testRemoveDirectorySymlinks2(): void
@@ -155,12 +155,12 @@ final class FileHelperTest extends TestCase
 
         $this->assertFileExists($basePath . 'file');
         $this->assertDirectoryExists($basePath . 'directory');
-        $this->assertFileNotExists($basePath . 'directory/standard-file-1'); // symlinked directory doesn't have it's file now
-        $this->assertDirectoryNotExists($basePath . 'symlinks');
-        $this->assertFileNotExists($basePath . 'symlinks/standard-file-2');
-        $this->assertFileNotExists($basePath . 'symlinks/symlinked-file');
-        $this->assertDirectoryNotExists($basePath . 'symlinks/symlinked-directory');
-        $this->assertFileNotExists($basePath . 'symlinks/symlinked-directory/standard-file-1');
+        $this->assertFileDoesNotExist($basePath . 'directory/standard-file-1'); // symlinked directory doesn't have it's file now
+        $this->assertDirectoryDoesNotExist($basePath . 'symlinks');
+        $this->assertFileDoesNotExist($basePath . 'symlinks/standard-file-2');
+        $this->assertFileDoesNotExist($basePath . 'symlinks/symlinked-file');
+        $this->assertDirectoryDoesNotExist($basePath . 'symlinks/symlinked-directory');
+        $this->assertFileDoesNotExist($basePath . 'symlinks/symlinked-directory/standard-file-1');
     }
 
     public function testNormalizePath(): void
@@ -287,7 +287,7 @@ final class FileHelperTest extends TestCase
         foreach ($structure as $name => $content) {
             $fileName = $destination . '/' . $name;
             if (is_array($content)) {
-                $this->assertFileNotExists($fileName);
+                $this->assertFileDoesNotExist($fileName);
             } else {
                 $this->assertFileExists($fileName);
                 $this->assertStringEqualsFile($fileName, $content, 'Incorrect file content!');
@@ -622,7 +622,7 @@ final class FileHelperTest extends TestCase
                 $this->checkNoexist($content, $dstDirName . '/' . $name);
             } else {
                 $fileName = $dstDirName . '/' . $name;
-                $this->assertFileNotExists($fileName);
+                $this->assertFileDoesNotExist($fileName);
             }
         }
     }

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -184,6 +184,9 @@ final class FileHelperTest extends TestCase
         $this->assertDirectoryExists($dirName);
         $this->assertFileDoesNotExist($dirName . '/file1.txt');
         $this->assertDirectoryDoesNotExist($dirName . '/test_sub_dir');
+
+        $this->expectException(\InvalidArgumentException::class);
+        FileHelper::clearDirectory($this->testFilePath . '/nonExisting');
     }
 
     public function testNormalizePath(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

- Add method `clearDirectory()` based on `removeDirectory()`.
- Add option `keepRootDirectory` to `removeDirectory()`.
- Replace deprecated PHPUnit methods in tests.