### PR TITLE
Fix #21: Fix Windows unlink() for "read only" files

### DIFF
--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -217,6 +217,10 @@ class FileHelper
             return rmdir($path);
         }
 
+        if (!is_writable($path)) {
+            chmod($path, 0777);
+        }
+
         return unlink($path);
     }
 

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -23,6 +23,7 @@ final class FileHelperTest extends TestCase
     {
         $this->testFilePath = FileHelper::normalizePath(realpath(sys_get_temp_dir()) . '/' . get_class($this));
 
+        FileHelper::removeDirectory($this->testFilePath);
         FileHelper::createDirectory($this->testFilePath, 0777);
 
         if (!file_exists($this->testFilePath)) {
@@ -758,6 +759,29 @@ final class FileHelperTest extends TestCase
         FileHelper::unlink($symlinkedDirectoryPath);
 
         $this->assertDirectoryDoesNotExist($symlinkedDirectoryPath);
+    }
+
+    /**
+     * 777 gives "read only" flag under Windows
+     * @see https://github.com/yiisoft/files/issues/21
+     */
+    public function testUnlinkFile777(): void
+    {
+        $dirName = 'unlink';
+        $basePath = $this->testFilePath . '/' . $dirName . '/';
+        $filePath = $basePath . 'file.txt';
+
+        $this->createFileStructure([
+            $dirName => [
+                'file.txt' => 'test',
+            ],
+        ]);
+        chmod($filePath, 777);
+
+        FileHelper::unlink($filePath);
+
+
+        $this->assertFileDoesNotExist($filePath);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #21
