### PR TITLE
Adopt psalm, add tests and minor fixes

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="6"
-    resolveFromConfigFile="true"
+    errorLevel="1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -189,7 +189,7 @@ class FileHelper
             return rmdir($path);
         }
 
-        if (!is_writable($path)) {
+        if (file_exists($path) && !is_writable($path)) {
             chmod($path, 0777);
         }
 

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -45,30 +45,7 @@ class FileHelper
             }
         }
 
-        return static::chmod($path, $mode);
-    }
-
-    /**
-     * Set permissions directory.
-     *
-     * @param string $path
-     * @param int $mode
-     *
-     * @throws RuntimeException
-     *
-     * @return bool
-     */
-    private static function chmod(string $path, int $mode): bool
-    {
-        try {
-            return chmod($path, $mode);
-        } catch (Exception $e) {
-            throw new RuntimeException(
-                'Failed to change permissions for directory "' . $path . '": ' . $e->getMessage(),
-                (int)$e->getCode(),
-                $e
-            );
-        }
+        return chmod($path, $mode);
     }
 
     /**
@@ -289,7 +266,7 @@ class FileHelper
                     }
                     copy($from, $to);
                     if (isset($options['fileMode'])) {
-                        static::chmod($to, $options['fileMode']);
+                        chmod($to, $options['fileMode']);
                     }
                 } elseif (!isset($options['recursive']) || $options['recursive']) {
                     static::copyDirectory($from, $to, $options);

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -311,5 +311,6 @@ final class FileHelperTest extends FileSystemTestCase
         );
 
         $this->assertIsInt(FileHelper::lastModifiedTime($basePath));
+        $this->assertIsInt(FileHelper::lastModifiedTime($basePath . '/css/stub.css'));
     }
 }

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -278,7 +278,7 @@ final class FileHelperTest extends FileSystemTestCase
         $this->assertDirectoryDoesNotExist($symlinkedDirectoryPath);
     }
 
-    public function testUnlinkNotExistsFile(): void
+    public function testUnlinkNonexistentFile(): void
     {
         $this->expectWarning();
         FileHelper::unlink($this->testFilePath . '/not-exists-file.txt');

--- a/tests/FileHelperTest.php
+++ b/tests/FileHelperTest.php
@@ -278,6 +278,12 @@ final class FileHelperTest extends FileSystemTestCase
         $this->assertDirectoryDoesNotExist($symlinkedDirectoryPath);
     }
 
+    public function testUnlinkNotExistsFile(): void
+    {
+        $this->expectWarning();
+        FileHelper::unlink($this->testFilePath . '/not-exists-file.txt');
+    }
+
     public function testIsEmptyDirectory(): void
     {
         $this->createFileStructure([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #16 

- Fix: in windows FileHelper::unlink() don't throws an E_WARNING level error for not exists file.
- Add test for FileHelper::lastModifiedTime().
- Adopt psalm.
- Remove private method FileHelper::chmod().