### PR TITLE
fix: Warning: mkdir(): File exists in FileHelper.php on line 64

### DIFF
--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -61,7 +61,7 @@ class FileHelper
         $path = static::normalizePath($path);
 
         try {
-            if (!mkdir($path, $mode, true) && !is_dir($path)) {
+            if (!is_dir($path) && !mkdir($path, $mode, true)) {
                 return false;
             }
         } catch (Exception $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
