### PR TITLE
Skip chmod if permission is already the same

### DIFF
--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -93,6 +93,11 @@ final class FileHelper
             restore_error_handler();
         }
 
+        // Skip chmod if permission is already the same
+        if (fileperms($path) == $mode) {
+            return;
+        }
+
         if (!chmod($path, $mode)) {
             throw new RuntimeException(sprintf('Unable to set mode "%s" for "%s".', $mode, $path));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

In the original code if chmod is not permitted, php 7.4 throws a warning and the exception actually won't get thrown. 

If we need to ensureDirectory an existing directory (which the developer may not know it existed and with sensitive permission), it will overwrite the original permission which may not be desired.