### PR TITLE
Fix return type for set_error_handler() callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.2 under development
 
-- Bug #56: Fix return type for callback of `set_error_handler()` function (devanych)
+- Bug #57: Fix return type for callback of `set_error_handler()` function (devanych)
 
 ## 1.0.1 December 18, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 1.0.2 under development
 
-- no changes in this release.
-
+- Bug #56: Fix return type for callback of `set_error_handler()` function (devanych)
 
 ## 1.0.1 December 18, 2021
 

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -42,7 +42,7 @@ final class FileHelper
     public static function openFile(string $filename, string $mode, bool $useIncludePath = false, $context = null)
     {
         /** @psalm-suppress InvalidArgument, MixedArgumentTypeCoercion */
-        set_error_handler(static function (int $errorNumber, string $errorString) use ($filename): ?bool {
+        set_error_handler(static function (int $errorNumber, string $errorString) use ($filename): bool {
             throw new RuntimeException(
                 sprintf('Failed to open a file "%s". ', $filename) . $errorString,
                 $errorNumber


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

See: https://www.php.net/manual/ru/function.set-error-handler
