### PR TITLE
Add/restore beforeCopy and afterCopy options

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -86,3 +86,6 @@ enabled:
   - trailing_comma_in_multiline_array
   - unalign_double_arrow
   - unalign_equals
+  - empty_loop_body_braces
+  - integer_literal_case
+  - union_type_without_spaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.3 under development
 
 - Bug #58: Add missed return value and type for callback of `set_error_handler()` function (vjik)
+- Feature #59: Add new `copyFile` method and `beforeCopy`, `afterCopy` callbacks
 
 ## 1.0.2 January 11, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bug #58: Add missed return value and type for callback of `set_error_handler()` function (vjik)
 - New #59: Add method `FileHelper::copyFile()` and for method `FileHelper::copyDirectory()` add callbacks
-  `beforeCopy`, `afterCopy`(Gerych1984)
+  `beforeCopy`, `afterCopy` (Gerych1984)
 
 ## 1.0.2 January 11, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## 1.1.0 under development
 
 - Bug #58: Add missed return value and type for callback of `set_error_handler()` function (vjik)
-- New #59: Add method `FileHelper::copyFile()` and for method `FileHelper::copyDirectory()` add callbacks
-  `beforeCopy`, `afterCopy` (Gerych1984)
+- New #59: Add `beforeCopy`, `afterCopy` callbacks for `FileHelper::copyFile()` and `FileHelper::copyDirectory()` (Gerych1984)
 
 ## 1.0.2 January 11, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Yii Files Change Log
 
-## 1.0.3 under development
+## 1.1.0 under development
 
 - Bug #58: Add missed return value and type for callback of `set_error_handler()` function (vjik)
-- Feature #59: Add new `copyFile` method and `beforeCopy`, `afterCopy` callbacks
+- New #59: Add method `FileHelper::copyFile()` and for method `FileHelper::copyDirectory()` add callbacks
+  `beforeCopy`, `afterCopy`(Gerych1984)
 
 ## 1.0.2 January 11, 2022
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yiisoft/files",
     "type": "library",
-    "description": "",
+    "description": "Helper to manage files and directories",
     "keywords": [
         "files"
     ],
@@ -20,10 +20,11 @@
         "yiisoft/strings": "^2.0"
     },
     "require-dev": {
+        "ext-zlib": "*",
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.16",
+        "roave/infection-static-analysis-plugin": "^1.18",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.18"
+        "vimeo/psalm": "^4.22"
     },
     "autoload": {
         "psr-4": {

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Files;
 
-use Closure;
 use FilesystemIterator;
 use InvalidArgumentException;
 use LogicException;
@@ -409,7 +408,7 @@ final class FileHelper
         }
 
         if ($fileMode !== null && !chmod($destination, $fileMode)) {
-            throw new RuntimeException('Failed to change file permissions.');
+            throw new RuntimeException(sprintf('Unable to set mode "%s" for "%s".', $fileMode, $destination));
         }
 
         self::processCallback($afterCopy, $source, $destination);
@@ -429,7 +428,7 @@ final class FileHelper
             return;
         }
 
-        if ($callback instanceof Closure || is_callable($callback)) {
+        if (is_callable($callback)) {
             return call_user_func_array($callback, $arguments);
         }
 

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -293,7 +293,7 @@ final class FileHelper
      * @psalm-param array{
      *   dirMode?: int,
      *   fileMode?: int,
-     *   filter?: \Yiisoft\Files\PathMatcher\PathMatcherInterface|mixed,
+     *   filter?: PathMatcherInterface|mixed,
      *   recursive?: bool,
      *   beforeCopy?: callable,
      *   afterCopy?: callable,
@@ -321,7 +321,7 @@ final class FileHelper
             return;
         }
 
-        if (!is_dir($destination) && $copyEmptyDirectories) {
+        if ($copyEmptyDirectories && !is_dir($destination)) {
             self::ensureDirectory($destination, $options['dirMode']);
         }
 
@@ -430,7 +430,12 @@ final class FileHelper
 
         $type = is_object($callback) ? get_class($callback) : gettype($callback);
 
-        throw new InvalidArgumentException('Argument $callback must be null, callable or Closure instance. "' . $type . '" given.');
+        throw new InvalidArgumentException(
+            sprintf(
+                'Argument $callback must be null, callable or Closure instance. %s given.',
+                $type
+            )
+        );
     }
 
     private static function getFilter(array $options): ?PathMatcherInterface
@@ -441,7 +446,9 @@ final class FileHelper
 
         if (!$options['filter'] instanceof PathMatcherInterface) {
             $type = is_object($options['filter']) ? get_class($options['filter']) : gettype($options['filter']);
-            throw new InvalidArgumentException(sprintf('Filter should be an instance of PathMatcherInterface, %s given.', $type));
+            throw new InvalidArgumentException(
+                sprintf('Filter should be an instance of PathMatcherInterface, %s given.', $type)
+            );
         }
 
         return $options['filter'];
@@ -557,7 +564,7 @@ final class FileHelper
      * - recursive: boolean, whether the subdirectories should also be looked for. Defaults to `true`.
      *
      * @psalm-param array{
-     *   filter?: \Yiisoft\Files\PathMatcher\PathMatcherInterface|mixed,
+     *   filter?: PathMatcherInterface|mixed,
      *   recursive?: bool,
      * } $options
      *
@@ -608,7 +615,7 @@ final class FileHelper
      * - recursive: boolean, whether the files under the subdirectories should also be looked for. Defaults to `true`.
      *
      * @psalm-param array{
-     *   filter?: \Yiisoft\Files\PathMatcher\PathMatcherInterface|mixed,
+     *   filter?: PathMatcherInterface|mixed,
      *   recursive?: bool,
      * } $options
      *

--- a/src/FileHelper.php
+++ b/src/FileHelper.php
@@ -386,7 +386,7 @@ final class FileHelper
         }
 
         $dirname = dirname($destination);
-        $dirMode = $options['dirMode'] ?? null;
+        $dirMode = $options['dirMode'] ?? 0755;
         $fileMode = $options['fileMode'] ?? null;
         $afterCopy = $options['afterCopy'] ?? null;
         $beforeCopy = $options['beforeCopy'] ?? null;
@@ -396,10 +396,6 @@ final class FileHelper
         }
 
         if (!is_dir($dirname)) {
-            if ($dirMode === null) {
-                throw new RuntimeException('Directory ' . $dirname . ' does not exist and cannot be created.');
-            }
-
             self::ensureDirectory($dirname, $dirMode);
         }
 

--- a/tests/FileHelperCallbackTest.php
+++ b/tests/FileHelperCallbackTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Files\Tests;
+
+use Yiisoft\Files\FileHelper;
+
+final class FileHelperCallbackTest extends FileSystemTestCase
+{
+    public function testSimpleBeforeCopy(): void
+    {
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+        ];
+
+        $this->createFileStructure([
+            $source => $files,
+        ]);
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        $options = [
+            'beforeCopy' => function (string $source, string $destination) use ($files, $basePath) {
+                $this->assertFileExists($source);
+
+                if (is_file($source)) {
+                    $basename = basename($source);
+                    $this->assertTrue(isset($files[$basename]));
+                    $this->assertStringEqualsFile($source, $files[$basename], 'Incorrect file content.');
+                } elseif (is_dir($source)) {
+                    $this->assertSame($basePath . '/test_src_dir', $source);
+                }
+            }
+        ];
+
+        FileHelper::copyDirectory($source, $destination, $options);
+    }
+
+    public function testBeforeCopyFalse(): void
+    {
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+        ];
+
+        $this->createFileStructure([
+            $source => $files,
+        ]);
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        $options = [
+            'beforeCopy' => static fn () => false,
+        ];
+
+        FileHelper::copyDirectory($source, $destination, $options);
+
+        $this->assertFileDoesNotExist($destination, 'Destination directory does exist.');
+
+        foreach ($files as $name => $content) {
+            $fileName = $destination . '/' . $name;
+            $this->assertFileDoesNotExist($fileName);
+        }
+    }
+
+    public function testBeforeCopyExclude(): void
+    {
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+            'config.ini' => 'some configuration',
+        ];
+
+        $this->createFileStructure([
+            $source => $files,
+        ]);
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        $options = [
+            'beforeCopy' => function (string $source) {
+                if (is_file($source)) {
+                    return pathinfo($source, PATHINFO_EXTENSION) === 'ini';
+                }
+            },
+        ];
+
+        FileHelper::copyDirectory($source, $destination, $options);
+
+        $this->assertFileExists($destination, 'Destination directory does not exist.');
+
+        foreach ($files as $name => $content) {
+            $fileName = $destination . '/' . $name;
+            $extension = pathinfo($fileName, PATHINFO_EXTENSION);
+
+            if ($extension === 'ini') {
+                $this->assertFileExists($fileName);
+            } else {
+                $this->assertFileDoesNotExist($fileName);
+            }
+        }
+    }
+
+    public function testAfterCopy(): void
+    {
+        $compressor = new class () {
+            public function compress(string $file): void
+            {
+                $mode = 'wb9';
+                $destination = $file . '.gz';
+
+                if (!is_file($file)) {
+                    return;
+                }
+
+                if ($fp_out = gzopen($destination, $mode)) {
+                    if ($fp_in = fopen($file, 'rb')) {
+                        while (!feof($fp_in)) {
+                            gzwrite($fp_out, fread($fp_in, 1024*512));
+                        }
+
+                        fclose($fp_in);
+                    }
+
+                    gzclose($fp_out);
+                }
+            }
+        };
+
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+        ];
+
+        $this->createFileStructure([
+            $source => $files,
+        ]);
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        $options = [
+            'afterCopy' => static fn ($source, $destination) => $compressor->compress($destination),
+        ];
+
+        FileHelper::copyDirectory($source, $destination, $options);
+
+        $this->assertFileExists($destination, 'Destination directory does not exist.');
+
+        foreach ($files as $name => $content) {
+            $destFile = $destination . '/' . $name;
+
+            $this->assertFileExists($destFile . '.gz');
+        }
+    }
+}

--- a/tests/FileHelperCopyFileTest.php
+++ b/tests/FileHelperCopyFileTest.php
@@ -81,8 +81,6 @@ final class FileHelperCopyFileTest extends FileSystemTestCase
             $destFile = $destination . '/' . $name;
 
             FileHelper::copyFile($sourceFile, $destFile);
-
-            $this->assertFileDoesNotExist($destFile);
         }
     }
 }

--- a/tests/FileHelperCopyFileTest.php
+++ b/tests/FileHelperCopyFileTest.php
@@ -52,15 +52,13 @@ final class FileHelperCopyFileTest extends FileSystemTestCase
         $source = $basePath . '/' . $source;
         $destination = $basePath . '/test_dst_dir';
 
-        $this->expectException(RuntimeException::class);
-
         foreach ($files as $name => $content) {
             $sourceFile = $source . '/' . $name;
             $destFile = $destination . '/' . $name;
 
             FileHelper::copyFile($sourceFile, $destFile);
 
-            $this->assertFileDoesNotExist($destFile);
+            $this->assertFileExists($destFile);
         }
     }
 

--- a/tests/FileHelperCopyFileTest.php
+++ b/tests/FileHelperCopyFileTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Files\Tests;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Yiisoft\Files\FileHelper;
+
+final class FileHelperCopyFileTest extends FileSystemTestCase
+{
+    public function testBaseCopy(): void
+    {
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+        ];
+
+        $this->createFileStructure([
+            $source => $files,
+        ]);
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        foreach ($files as $name => $content) {
+            $sourceFile = $source . '/' . $name;
+            $destFile = $destination . '/' . $name;
+
+            FileHelper::copyFile($sourceFile, $destFile, ['dirMode' => 0755]);
+
+            $this->assertFileExists($destFile);
+        }
+    }
+
+    public function testCopyWithNoDir(): void
+    {
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+        ];
+
+        $this->createFileStructure([
+            $source => $files,
+        ]);
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        $this->expectException(RuntimeException::class);
+
+        foreach ($files as $name => $content) {
+            $sourceFile = $source . '/' . $name;
+            $destFile = $destination . '/' . $name;
+
+            FileHelper::copyFile($sourceFile, $destFile);
+
+            $this->assertFileDoesNotExist($destFile);
+        }
+    }
+
+    public function testCopyWithNoSource(): void
+    {
+        $source = 'test_src_dir';
+        $files = [
+            'file1.txt' => 'file 1 content',
+            'file2.txt' => 'file 2 content',
+        ];
+
+        $basePath = $this->testFilePath;
+        $source = $basePath . '/' . $source;
+        $destination = $basePath . '/test_dst_dir';
+
+        $this->expectException(InvalidArgumentException::class);
+
+        foreach ($files as $name => $content) {
+            $sourceFile = $source . '/' . $name;
+            $destFile = $destination . '/' . $name;
+
+            FileHelper::copyFile($sourceFile, $destFile);
+
+            $this->assertFileDoesNotExist($destFile);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

1. Add `FileHelper::copyFile` method
2. Add `beforeCopy` and `afterCopy` options to `FileHelper::copyDirectory` and `FileHelper::copyFile`